### PR TITLE
Add modular report generator framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install deps
+        run: pip install -r requirements.txt pytest reportlab
+      - name: Run tests
+        run: pytest --maxfail=1 --disable-warnings -q
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v3
+        with:
+          name: reports
+          path: tests/*.pdf

--- a/report_engine.py
+++ b/report_engine.py
@@ -1,0 +1,46 @@
+import json, importlib, os
+from reportlab.pdfgen import canvas
+
+
+def load_config():
+    with open("reports_config.json") as f:
+        return json.load(f)
+
+
+def load_data(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def main(report_type, input_path, occasion, output_path):
+    cfg = load_config()[report_type]
+    data = load_data(input_path)
+
+    # Basic validation against the schema stub. Only check top-level keys.
+    schema = load_data(cfg["schema"])
+    missing = [k for k in schema.keys() if k not in data]
+    if missing:
+        raise KeyError(f"Missing keys for {report_type}: {missing}")
+
+    prompts_module = importlib.import_module(
+        f"src.prompts.{report_type}.prompt_definitions_{report_type}"
+    )
+    c = canvas.Canvas(output_path)
+    for section in prompts_module.SECTIONS:
+        prompt = prompts_module.get_prompt(section, data, occasion)
+        # 1) call OpenAI API with prompt → text
+        # 2) c.drawString(...) or advanced layout
+        c.showPage()
+    c.save()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--type", required=True, choices=["numerology", "destiny_matrix", "astrocartography"])
+    p.add_argument("--input", required=True)
+    p.add_argument("--occasion", required=True, choices=["self_discovery", "gift"])
+    p.add_argument("--output", required=True)
+    args = p.parse_args()
+    main(args.type, args.input, args.occasion, args.output)

--- a/reports_config.json
+++ b/reports_config.json
@@ -1,0 +1,17 @@
+{
+  "numerology": {
+    "schema": "src/schemas/numerology_schema.json",
+    "prompts": "src/prompts/numerology/",
+    "occasions": ["self_discovery","gift"]
+  },
+  "destiny_matrix": {
+    "schema": "src/schemas/destiny_matrix_schema.json",
+    "prompts": "src/prompts/destiny_matrix/",
+    "occasions": ["self_discovery","gift"]
+  },
+  "astrocartography": {
+    "schema": "src/schemas/astrocartography_schema.json",
+    "prompts": "src/prompts/astrocartography/",
+    "occasions": ["self_discovery","gift"]
+  }
+}

--- a/run_report.py
+++ b/run_report.py
@@ -1,0 +1,4 @@
+from report_engine import main
+# CLI logic is already in report_engine; you can simply:
+# python run_report.py --type ... --input ... --occasion ... --output ...
+# or symlink run_report.py → report_engine.py

--- a/src/prompts/astrocartography/prompt_definitions_astrocartography.py
+++ b/src/prompts/astrocartography/prompt_definitions_astrocartography.py
@@ -1,0 +1,7 @@
+SECTIONS = [
+    "Locations"
+]
+
+def get_prompt(section, data, occasion):
+    # TODO: fill in actual prompt templates
+    return f"[AI Expansion Point for {section}]"

--- a/src/prompts/destiny_matrix/prompt_definitions_destiny_matrix.py
+++ b/src/prompts/destiny_matrix/prompt_definitions_destiny_matrix.py
@@ -1,0 +1,11 @@
+SECTIONS = [
+    "Life Path Number",
+    "Challenge Numbers",
+    "Innate Talent Number",
+    "Balance Number",
+    "Cycles"
+]
+
+def get_prompt(section, data, occasion):
+    # TODO: fill in actual prompt templates
+    return f"[AI Expansion Point for {section}]"

--- a/src/prompts/numerology/prompt_definitions_numerology.py
+++ b/src/prompts/numerology/prompt_definitions_numerology.py
@@ -1,0 +1,14 @@
+SECTIONS = [
+    "Destiny Number",
+    "Soul Urge Number",
+    "Expression Number",
+    "Personality Number",
+    "Birth Day Number",
+    "Personal Year Number",
+    "Master Numbers"
+]
+
+# Each section: yield a prompt template or function to return the exact prompt text.
+def get_prompt(section, data, occasion):
+    # TODO: fill in actual prompt templates
+    return f"[AI Expansion Point for {section}]"

--- a/src/schemas/astrocartography_schema.json
+++ b/src/schemas/astrocartography_schema.json
@@ -1,0 +1,12 @@
+{
+  "name": "string",
+  "date_of_birth": "YYYY-MM-DD",
+  "locations": [
+    {
+      "place_name": "string",
+      "latitude": 0.0,
+      "longitude": 0.0,
+      "lines": []
+    }
+  ]
+}

--- a/src/schemas/destiny_matrix_schema.json
+++ b/src/schemas/destiny_matrix_schema.json
@@ -1,0 +1,9 @@
+{
+  "name": "string",
+  "date_of_birth": "YYYY-MM-DD",
+  "life_path_number": 0,
+  "challenge_numbers": [0,0],
+  "innate_talent_number": 0,
+  "balance_number": 0,
+  "cycles": {}
+}

--- a/src/schemas/numerology_schema.json
+++ b/src/schemas/numerology_schema.json
@@ -1,0 +1,11 @@
+{
+  "name": "string",
+  "date_of_birth": "YYYY-MM-DD",
+  "destiny_number": 0,
+  "soul_urge_number": 0,
+  "expression_number": 0,
+  "personality_number": 0,
+  "birth_day_number": 0,
+  "personal_year_number": 0,
+  "master_numbers": []
+}

--- a/tests/samples/astrocartography_missing.json
+++ b/tests/samples/astrocartography_missing.json
@@ -1,0 +1,3 @@
+{
+  "name": "Jane Doe"
+}

--- a/tests/samples/astrocartography_valid.json
+++ b/tests/samples/astrocartography_valid.json
@@ -1,0 +1,12 @@
+{
+  "name": "John Doe",
+  "date_of_birth": "1980-01-01",
+  "locations": [
+    {
+      "place_name": "New York",
+      "latitude": 40.7128,
+      "longitude": -74.0060,
+      "lines": []
+    }
+  ]
+}

--- a/tests/samples/destiny_matrix_missing.json
+++ b/tests/samples/destiny_matrix_missing.json
@@ -1,0 +1,3 @@
+{
+  "name": "Jane Doe"
+}

--- a/tests/samples/destiny_matrix_valid.json
+++ b/tests/samples/destiny_matrix_valid.json
@@ -1,0 +1,9 @@
+{
+  "name": "John Doe",
+  "date_of_birth": "1980-01-01",
+  "life_path_number": 4,
+  "challenge_numbers": [1,2],
+  "innate_talent_number": 8,
+  "balance_number": 3,
+  "cycles": {}
+}

--- a/tests/samples/numerology_missing.json
+++ b/tests/samples/numerology_missing.json
@@ -1,0 +1,3 @@
+{
+  "name": "Jane Doe"
+}

--- a/tests/samples/numerology_valid.json
+++ b/tests/samples/numerology_valid.json
@@ -1,0 +1,11 @@
+{
+  "name": "John Doe",
+  "date_of_birth": "1980-01-01",
+  "destiny_number": 5,
+  "soul_urge_number": 7,
+  "expression_number": 3,
+  "personality_number": 2,
+  "birth_day_number": 1,
+  "personal_year_number": 9,
+  "master_numbers": []
+}

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,21 @@
+import pytest, os
+from report_engine import main
+
+@pytest.mark.parametrize("rtype,sample", [
+    ("numerology", "tests/samples/numerology_valid.json"),
+    ("destiny_matrix", "tests/samples/destiny_matrix_valid.json"),
+    ("astrocartography", "tests/samples/astrocartography_valid.json"),
+])
+def test_valid_report(tmp_path, rtype, sample):
+    out = tmp_path / f"{rtype}.pdf"
+    main(rtype, sample, "self_discovery", str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+@pytest.mark.parametrize("rtype,sample", [
+    ("numerology", "tests/samples/numerology_missing.json"),
+    ("destiny_matrix", "tests/samples/destiny_matrix_missing.json"),
+    ("astrocartography", "tests/samples/astrocartography_missing.json"),
+])
+def test_missing_field(tmp_path, rtype, sample):
+    with pytest.raises(Exception):
+        main(rtype, sample, "gift", str(tmp_path / "fail.pdf"))


### PR DESCRIPTION
## Summary
- configure available report types with `reports_config.json`
- stub schemas for numerology, destiny matrix, and astrocartography
- add stub prompt definitions for each report type
- implement `report_engine.py` with simple schema validation
- provide thin wrapper `run_report.py`
- supply pytest suite with sample JSON fixtures
- add CI workflow to run tests

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_684445f5f8788329be8951676c7c75f5