### PR TITLE
Add sample data and prompt modules

### DIFF
--- a/src/prompts/astrocartography/prompt_definitions_astrocartography.py
+++ b/src/prompts/astrocartography/prompt_definitions_astrocartography.py
@@ -1,0 +1,11 @@
+"""Prompt helper for astrocartography reports."""
+
+def get_prompt(section, data, occasion):
+    """Return the text prompt for an astrocartography report section."""
+    return (
+        f"Astrocartography Report – {section}\n"
+        f"Name: {data['name']}\n"
+        f"Date of Birth: {data['date_of_birth']}\n"
+        f"Occasion: {occasion}\n\n"
+        f"[AI Expansion Point: Please provide an insightful analysis of the {section} based on the data above.]"
+    )

--- a/src/prompts/destiny_matrix/prompt_definitions_destiny_matrix.py
+++ b/src/prompts/destiny_matrix/prompt_definitions_destiny_matrix.py
@@ -1,0 +1,11 @@
+"""Prompt helper for destiny matrix reports."""
+
+def get_prompt(section, data, occasion):
+    """Return the text prompt for a destiny matrix report section."""
+    return (
+        f"Destiny Matrix Report – {section}\n"
+        f"Name: {data['name']}\n"
+        f"Date of Birth: {data['date_of_birth']}\n"
+        f"Occasion: {occasion}\n\n"
+        f"[AI Expansion Point: Please provide an insightful analysis of the {section} based on the data above.]"
+    )

--- a/src/prompts/numerology/prompt_definitions_numerology.py
+++ b/src/prompts/numerology/prompt_definitions_numerology.py
@@ -1,0 +1,11 @@
+"""Prompt helper for numerology reports."""
+
+def get_prompt(section, data, occasion):
+    """Return the text prompt for a numerology report section."""
+    return (
+        f"Numerology Report – {section}\n"
+        f"Name: {data['name']}\n"
+        f"Date of Birth: {data['date_of_birth']}\n"
+        f"Occasion: {occasion}\n\n"
+        f"[AI Expansion Point: Please provide an insightful analysis of the {section} based on the data above.]"
+    )

--- a/tests/samples/astrocartography_missing.json
+++ b/tests/samples/astrocartography_missing.json
@@ -1,0 +1,4 @@
+{
+  "name": "Charlie Example",
+  "date_of_birth": "1975-12-15"
+}

--- a/tests/samples/astrocartography_valid.json
+++ b/tests/samples/astrocartography_valid.json
@@ -1,0 +1,12 @@
+{
+  "name": "Charlie Example",
+  "date_of_birth": "1975-12-15",
+  "locations": [
+    {
+      "place_name": "Paris, France",
+      "latitude": 48.8566,
+      "longitude": 2.3522,
+      "lines": ["sun", "moon"]
+    }
+  ]
+}

--- a/tests/samples/destiny_matrix_missing.json
+++ b/tests/samples/destiny_matrix_missing.json
@@ -1,0 +1,11 @@
+{
+  "name": "Bob Sample",
+  "date_of_birth": "1990-01-01",
+  "challenge_numbers": [2, 9],
+  "innate_talent_number": 3,
+  "balance_number": 5,
+  "cycles": {
+    "personal_cycle": 1,
+    "second_cycle": 2
+  }
+}

--- a/tests/samples/destiny_matrix_valid.json
+++ b/tests/samples/destiny_matrix_valid.json
@@ -1,0 +1,12 @@
+{
+  "name": "Bob Sample",
+  "date_of_birth": "1990-01-01",
+  "life_path_number": 8,
+  "challenge_numbers": [2, 9],
+  "innate_talent_number": 3,
+  "balance_number": 5,
+  "cycles": {
+    "personal_cycle": 1,
+    "second_cycle": 2
+  }
+}

--- a/tests/samples/numerology_missing.json
+++ b/tests/samples/numerology_missing.json
@@ -1,0 +1,10 @@
+{
+  "name": "Alice Example",
+  "date_of_birth": "1984-07-28",
+  "soul_urge_number": 7,
+  "expression_number": 2,
+  "personality_number": 3,
+  "birth_day_number": 7,
+  "personal_year_number": 4,
+  "master_numbers": [11, 22]
+}

--- a/tests/samples/numerology_valid.json
+++ b/tests/samples/numerology_valid.json
@@ -1,0 +1,11 @@
+{
+  "name": "Alice Example",
+  "date_of_birth": "1984-07-28",
+  "destiny_number": 5,
+  "soul_urge_number": 7,
+  "expression_number": 2,
+  "personality_number": 3,
+  "birth_day_number": 7,
+  "personal_year_number": 4,
+  "master_numbers": [11, 22]
+}


### PR DESCRIPTION
## Summary
- add JSON samples for numerology, destiny matrix, and astrocartography
- create prompts modules for numerology, destiny matrix, and astrocartography
- implement simple `get_prompt` helpers in each module

## Testing
- `python -m py_compile src/prompts/numerology/prompt_definitions_numerology.py src/prompts/destiny_matrix/prompt_definitions_destiny_matrix.py src/prompts/astrocartography/prompt_definitions_astrocartography.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684447da5de0832983db3166c8f3e67e