### PR TITLE
Scaffold standalone astrology report module

### DIFF
--- a/reports_config.json
+++ b/reports_config.json
@@ -1,0 +1,10 @@
+{
+  "astrology": {
+    "schema": "src/schemas/astrology_schema.json",
+    "prompts": "src/prompts/astrology/",
+    "occasions": [
+      "self_discovery",
+      "gift"
+    ]
+  }
+}

--- a/run_report.py
+++ b/run_report.py
@@ -1,0 +1,51 @@
+import argparse
+import json
+import os
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'reports_config.json')
+
+
+def load_config():
+    with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def load_schema(schema_path):
+    with open(schema_path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def validate_data(report_type, data):
+    config = load_config()
+    if report_type not in config:
+        raise ValueError(f"Unknown report type: {report_type}")
+    schema = load_schema(config[report_type]['schema'])
+    missing = []
+    for key, value in schema.items():
+        if key not in data:
+            missing.append(key)
+        elif isinstance(value, dict):
+            # shallow check for nested keys
+            for subkey in value:
+                if subkey not in data[key]:
+                    missing.append(f"{key}.{subkey}")
+    if missing:
+        raise ValueError(f"Missing fields: {', '.join(missing)}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Generate reports")
+    config = load_config()
+    parser.add_argument('report_type', choices=list(config.keys()))
+    parser.add_argument('data_file')
+    parser.add_argument('--occasion', default='self_discovery')
+    args = parser.parse_args(argv)
+
+    with open(args.data_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    validate_data(args.report_type, data)
+    print(f"Validated {args.report_type} report for {data.get('name')}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/prompts/astrology/prompt_definitions_astrology.py
+++ b/src/prompts/astrology/prompt_definitions_astrology.py
@@ -1,0 +1,19 @@
+SECTIONS = [
+  "Sun Sign",
+  "Moon Sign",
+  "Rising Sign",
+  "Mercury Placement",
+  "Venus Placement",
+  "Mars Placement",
+  "Aspects Overview",
+  "House Highlights"
+]
+
+def get_prompt(section, data, occasion):
+    return (
+      f"Astrology Report – {section}\n"
+      f"Name: {data['name']}\n"
+      f"Birth: {data['date_of_birth']} at {data['birth_time']} in {data['place_of_birth']}\n"
+      f"Occasion: {occasion}\n\n"
+      f"[AI Expansion Point: Provide a deep, insightful analysis of the {section} based on the chart data above.]"
+    )

--- a/src/schemas/astrology_schema.json
+++ b/src/schemas/astrology_schema.json
@@ -1,0 +1,20 @@
+{
+  "name": "string",
+  "date_of_birth": "YYYY-MM-DD",
+  "birth_time": "HH:MM",
+  "place_of_birth": "string",
+  "planets": {
+    "Sun": "string",
+    "Moon": "string",
+    "Mercury": "string",
+    "Venus": "string",
+    "Mars": "string",
+    "Jupiter": "string",
+    "Saturn": "string",
+    "Uranus": "string",
+    "Neptune": "string",
+    "Pluto": "string"
+  },
+  "ascendant": "string",
+  "houses": {}
+}

--- a/tests/samples/astrology_missing.json
+++ b/tests/samples/astrology_missing.json
@@ -1,0 +1,19 @@
+{
+  "name": "Alice Example",
+  "date_of_birth": "1990-01-01",
+  "place_of_birth": "Springfield",
+  "planets": {
+    "Sun": "Capricorn",
+    "Moon": "Leo",
+    "Mercury": "Sagittarius",
+    "Venus": "Aquarius",
+    "Mars": "Scorpio",
+    "Jupiter": "Cancer",
+    "Saturn": "Capricorn",
+    "Uranus": "Capricorn",
+    "Neptune": "Capricorn",
+    "Pluto": "Scorpio"
+  },
+  "ascendant": "Gemini",
+  "houses": {}
+}

--- a/tests/samples/astrology_valid.json
+++ b/tests/samples/astrology_valid.json
@@ -1,0 +1,20 @@
+{
+  "name": "Alice Example",
+  "date_of_birth": "1990-01-01",
+  "birth_time": "12:00",
+  "place_of_birth": "Springfield",
+  "planets": {
+    "Sun": "Capricorn",
+    "Moon": "Leo",
+    "Mercury": "Sagittarius",
+    "Venus": "Aquarius",
+    "Mars": "Scorpio",
+    "Jupiter": "Cancer",
+    "Saturn": "Capricorn",
+    "Uranus": "Capricorn",
+    "Neptune": "Capricorn",
+    "Pluto": "Scorpio"
+  },
+  "ascendant": "Gemini",
+  "houses": {}
+}

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,33 @@
+import json
+import os
+import importlib.util
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "run_report",
+    os.path.join(os.path.dirname(__file__), os.pardir, "run_report.py")
+)
+run_report = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(run_report)
+validate_data = run_report.validate_data
+
+VALID_SAMPLES = {
+    "astrology": "tests/samples/astrology_valid.json",
+}
+
+MISSING_SAMPLES = {
+    "astrology": "tests/samples/astrology_missing.json",
+}
+
+@pytest.mark.parametrize("report_type, path", VALID_SAMPLES.items())
+def test_valid_reports(report_type, path):
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    validate_data(report_type, data)
+
+@pytest.mark.parametrize("report_type, path", MISSING_SAMPLES.items())
+def test_missing_reports(report_type, path):
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    with pytest.raises(ValueError):
+        validate_data(report_type, data)


### PR DESCRIPTION
## Summary
- add new `astrology` entry in `reports_config.json`
- scaffold astrology schema and prompts under `src/`
- implement a simple CLI in `run_report.py`
- create fixtures and tests for astrology report validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446209c0f083299b8fee4bada8fe05