### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run tests
         run: pytest --maxfail=1 --disable-warnings -q
       - name: Upload PDFs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: tests/*.pdf


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use upload-artifact@v4

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'report_engine')*
- `pip install -r requirements.txt pytest reportlab openai` *(fails: Could not find a version that satisfies the requirement reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_684494197c4883298c9e2d44328abe58