### PR TITLE
Add package setup and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install deps
-        run: pip install -r requirements.txt pytest reportlab openai
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pytest
       - name: Run tests
         run: pytest --maxfail=1 --disable-warnings -q
       - name: Upload PDFs

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name="lumenaurareports",
+    version="0.1.0",
+    py_modules=["report_engine", "run_report"],
+    install_requires=[
+        "reportlab",
+        "openai"
+    ],
+)


### PR DESCRIPTION
## Summary
- allow installing `report_engine` with a minimal `setup.py`
- update CI workflow to install the package using `pip install -e .`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'report_engine')*

------
https://chatgpt.com/codex/tasks/task_e_68449b1d77b8832984312f28b895d88a