### PR TITLE
Break circular import by moving validate_data

### DIFF
--- a/report_engine.py
+++ b/report_engine.py
@@ -1,8 +1,17 @@
 import json
+import os
 import importlib
 from reportlab.pdfgen import canvas
 import openai
-from run_report import validate_data
+
+
+def validate_data(report_type, data):
+    cfg = load_config()[report_type]
+    with open(cfg["schema"]) as f:
+        schema = json.load(f)
+    missing = [k for k in schema.keys() if k not in data]
+    if missing:
+        raise KeyError(f"Missing keys for {report_type}: {missing}")
 
 
 def load_config():

--- a/run_report.py
+++ b/run_report.py
@@ -1,16 +1,7 @@
 import argparse
 import json
 from report_engine import main, load_config
-
-
-def validate_data(report_type, data):
-    cfg = load_config()[report_type]
-    with open(cfg["schema"]) as f:
-        schema = json.load(f)
-    missing = [k for k in schema.keys() if k not in data]
-    if missing:
-        raise KeyError(f"Missing keys for {report_type}: {missing}")
-
+from report_engine import validate_data
 
 def cli():
     config = load_config()


### PR DESCRIPTION
## Summary
- move the `validate_data` helper from `run_report` to `report_engine`
- update `run_report` to import `validate_data` from the new location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_68449f5a1c90832992b48f5eef61a627