### PR TITLE
Refactor to remove circular imports and simplify CLI/tests

### DIFF
--- a/report_engine.py
+++ b/report_engine.py
@@ -1,17 +1,6 @@
-import json
-import os
-import importlib
+import json, os, importlib
 from reportlab.pdfgen import canvas
 import openai
-
-
-def validate_data(report_type, data):
-    cfg = load_config()[report_type]
-    with open(cfg["schema"]) as f:
-        schema = json.load(f)
-    missing = [k for k in schema.keys() if k not in data]
-    if missing:
-        raise KeyError(f"Missing keys for {report_type}: {missing}")
 
 
 def load_config():
@@ -22,6 +11,15 @@ def load_config():
 def load_data(path):
     with open(path) as f:
         return json.load(f)
+
+
+def validate_data(report_type, data):
+    cfg = load_config()[report_type]
+    with open(cfg["schema"]) as f:
+        schema = json.load(f)
+    missing = [k for k in schema.keys() if k not in data]
+    if missing:
+        raise KeyError(f"Missing keys for {report_type}: {missing}")
 
 
 def _call_openai(prompt):
@@ -60,14 +58,3 @@ def main(report_type, input_path, occasion, output_path):
     c.save()
 
 
-if __name__ == "__main__":
-    import argparse
-
-    cfg = load_config()
-    p = argparse.ArgumentParser()
-    p.add_argument("--type", required=True, choices=list(cfg.keys()))
-    p.add_argument("--input", required=True)
-    p.add_argument("--occasion", required=True)
-    p.add_argument("--output", required=True)
-    args = p.parse_args()
-    main(args.type, args.input, args.occasion, args.output)

--- a/run_report.py
+++ b/run_report.py
@@ -1,18 +1,13 @@
 import argparse
-import json
-from report_engine import main, load_config
-from report_engine import validate_data
+from report_engine import main
 
-def cli():
-    config = load_config()
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--type", required=True, choices=list(config.keys()))
-    parser.add_argument("--input", required=True)
-    parser.add_argument("--occasion", required=True)
-    parser.add_argument("--output", required=True)
-    args = parser.parse_args()
-    main(args.type, args.input, args.occasion, args.output)
-
+REPORT_TYPES = ["numerology", "destiny_matrix", "astrocartography", "astrology"]
 
 if __name__ == "__main__":
-    cli()
+    p = argparse.ArgumentParser()
+    p.add_argument("--type", required=True, choices=REPORT_TYPES)
+    p.add_argument("--input", required=True)
+    p.add_argument("--occasion", default="self_discovery")
+    p.add_argument("--output", required=True)
+    args = p.parse_args()
+    main(args.type, args.input, args.occasion, args.output)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,5 +1,8 @@
-import pytest, os
-from report_engine import main
+import os, sys
+sys.path.insert(0, os.getcwd())
+
+import pytest
+from report_engine import main, validate_data
 
 @pytest.mark.parametrize("rtype,sample", [
     ("numerology", "tests/samples/numerology_valid.json"),


### PR DESCRIPTION
## Summary
- clean up report_engine imports and remove CLI
- shrink run_report to a simple wrapper over `main`
- update tests to import directly from report_engine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_6844a6cc0eac83298e3132dc87f0b040